### PR TITLE
Add React home page with collapsible menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# winman
+# Winman
+
+This repository contains a minimal client for a human resource management system.
+
+The `client` directory hosts a small React-based UI that demonstrates a home page
+with a collapsible tree menu on the left side. It loads React 18 from a CDN so
+no build step is required.
+
+To preview the client, open `client/index.html` in a modern browser.

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>人材ビジネス管理システム</title>
+    <style>
+      body { margin: 0; font-family: Arial, sans-serif; }
+      #container { display: flex; height: 100vh; }
+      .sidebar {
+        width: 250px; background-color: #f2f2f2; overflow-y: auto;
+        transition: transform 0.3s ease-in-out;
+      }
+      .sidebar.hidden { transform: translateX(-100%); }
+      .content { flex: 1; padding: 20px; }
+      .toggle-btn { position: absolute; top: 10px; left: 10px; }
+      ul.tree { list-style-type: none; padding-left: 20px; }
+      ul.tree li { cursor: pointer; margin: 4px 0; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+    <script type="text/babel" src="./src/main.jsx"></script>
+  </body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "winman-client",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,0 +1,50 @@
+const { useState } = React;
+
+function TreeItem({ label, children }) {
+  const [open, setOpen] = useState(false);
+  const hasChildren = React.Children.count(children) > 0;
+
+  return (
+    <li>
+      <div onClick={() => hasChildren && setOpen(!open)}>
+        {label}
+      </div>
+      {hasChildren && open && <ul className="tree">{children}</ul>}
+    </li>
+  );
+}
+
+function TreeMenu() {
+  return (
+    <ul className="tree">
+      <TreeItem label="メニュー1">
+        <TreeItem label="サブメニュー1-1" />
+        <TreeItem label="サブメニュー1-2" />
+      </TreeItem>
+      <TreeItem label="メニュー2">
+        <TreeItem label="サブメニュー2-1" />
+      </TreeItem>
+    </ul>
+  );
+}
+
+function App() {
+  const [hidden, setHidden] = useState(false);
+  return (
+    <div id="container">
+      <div className={hidden ? "sidebar hidden" : "sidebar"}>
+        <TreeMenu />
+      </div>
+      <button className="toggle-btn" onClick={() => setHidden(!hidden)}>
+        {hidden ? "メニューを表示" : "メニューを隠す"}
+      </button>
+      <div className="content">
+        <h1>ホーム</h1>
+        <p>ようこそ、管理システムへ</p>
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+


### PR DESCRIPTION
## Summary
- set up a minimal React client
- implement home page with left sidebar tree menu
- sidebar supports hide/show toggle

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6858a6a9c8388324848f1d7b41460155